### PR TITLE
Allow extensions to provide customized DataSource classes

### DIFF
--- a/CRM/Streetimport/Config.php
+++ b/CRM/Streetimport/Config.php
@@ -206,6 +206,16 @@ class CRM_Streetimport_Config {
   }
 
   /**
+   * get the default the DataSourceClass to work with
+   *
+   * @return a subclass of CRM_Streetimport_DataSource
+   */
+  public function getDataSourceClass($logger) {
+    // this can be overwritten to provide a customized DataSourceClass
+    return CRM_Streetimport_FileCsvDataSource;
+  }
+
+  /**
    * this can be overwritte to reject certain files
    *
    * @return TRUE if all is well.

--- a/CRM/Streetimport/FileCsvDataSource.php
+++ b/CRM/Streetimport/FileCsvDataSource.php
@@ -23,8 +23,8 @@ class CRM_Streetimport_FileCsvDataSource extends CRM_Streetimport_DataSource {
   public function __construct($uri, $logger, $mapping = NULL, $encoding = NULL, $delimiter = NULL) {
     CRM_Streetimport_DataSource::__construct($uri, $logger, $mapping);
     $config = CRM_Streetimport_Config::singleton();
-    $this->encoding = $encoding ?: $config->getSetting('import_encoding', 'UTF8');
-    $this->delimiter = $delimiter ?: $config->getSetting('import_delimiter', ';');
+    $this->encoding = $encoding ?: $config->getSetting('import_encoding', $this->encoding);
+    $this->delimiter = $delimiter ?: $config->getSetting('import_delimiter', $this->delimiter);
   }
 
   /**

--- a/api/v3/Streetimport.php
+++ b/api/v3/Streetimport.php
@@ -24,6 +24,7 @@
  */
 function civicrm_api3_streetimport_importcsvfile($params) {
   $config = CRM_Streetimport_Config::singleton();
+  $data_source_class = $config->getDataSourceClass();
   $result = new CRM_Streetimport_ImportResult();
 
   // first, get the parameters sorted out
@@ -121,7 +122,7 @@ function civicrm_api3_streetimport_importcsvfile($params) {
       $result->logMessage("Moved file '{$source_file}' to '{$processing_file}' for processing.", NULL, BE_AIVL_STREETIMPORT_ERROR);
 
       // STEP 2: process the file
-      $dataSource = new CRM_Streetimport_FileCsvDataSource($processing_file, $result, NULL, $encoding, $delimiter);
+      $dataSource = new $data_source_class($processing_file, $result, NULL, $encoding, $delimiter);
       CRM_Streetimport_RecordHandler::processDataSource($dataSource);
 
       // STEP 3: move file + log to completed folder
@@ -220,7 +221,7 @@ function civicrm_api3_streetimport_tm($params) {
 
         //TODO The mapping is currently defined at the data source level, but we want to use a different mapping per handler.
 
-        $dataSource = new CRM_Streetimport_FileCsvDataSource($source_file, $result);
+        $dataSource = new $data_source_class($source_file, $result);
 
         CRM_Streetimport_RecordHandler::processDataSource($dataSource);
         exit;


### PR DESCRIPTION
For complementing extensions it might be useful to define their own DataSource class. A usecase could be the processing of headerless csv files. Retrieving the DataSource class from the CRM_Streetimport_Config class by a class method allows a complementing extension to provide a customized DataSource class by overwriting this method.